### PR TITLE
Specific games presence

### DIFF
--- a/data/games.json
+++ b/data/games.json
@@ -449,6 +449,18 @@
       "description": "Organize and sequence organic elements to improve logical reasoning and pattern recognition",
       "category": "PROBLEM_SOLVING",
       "icon": "/icons/organic-order.png"
+    },
+    {
+      "name": "Cognition Kitchen",
+      "description": "Cook up solutions by adapting to changing recipes and kitchen rules to improve cognitive flexibility",
+      "category": "FLEXIBILITY",
+      "icon": "/icons/cognition-kitchen.png"
+    },
+    {
+      "name": "Halve your cake",
+      "description": "Divide cakes fairly and solve fraction puzzles to improve mathematical reasoning and problem-solving",
+      "category": "PROBLEM_SOLVING",
+      "icon": "/icons/halve-your-cake.png"
     }
   ]
 }


### PR DESCRIPTION
Add missing Lumosity games: Cognition Kitchen and Halve your cake.

These games were identified as missing from `data/games.json` and have been added to ensure the leaderboard is complete. Run `npm run db:seed` after merge to load the new games.

---
[Slack Thread](https://elabio.slack.com/archives/D0AHJGF2XAS/p1772327897186769?thread_ts=1772327897.186769&cid=D0AHJGF2XAS)

<p><a href="https://cursor.com/agents/bc-3d232834-91cc-5db5-becc-dc164b633232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d232834-91cc-5db5-becc-dc164b633232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

