### PR TITLE
Game selection type-ahead

### DIFF
--- a/components/ScoreEntryForm.tsx
+++ b/components/ScoreEntryForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { submitScore } from '@/app/actions/scores'
 
 interface Game {
@@ -16,9 +16,99 @@ interface ScoreEntryFormProps {
 
 export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
   const [selectedGame, setSelectedGame] = useState('')
+  const [selectedGameName, setSelectedGameName] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
   const [score, setScore] = useState('')
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  const filteredGames = games.filter(
+    (game) =>
+      game.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      game.category.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+
+  const displayValue = selectedGame ? selectedGameName : searchQuery
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setSearchQuery(value)
+    setSelectedGame('')
+    setSelectedGameName('')
+    setIsOpen(true)
+    setHighlightedIndex(-1)
+  }
+
+  const handleInputFocus = () => {
+    setIsOpen(true)
+    if (!selectedGame) {
+      setSearchQuery('')
+    }
+  }
+
+  const handleSelectGame = (game: Game) => {
+    setSelectedGame(game.id)
+    setSelectedGameName(game.name)
+    setSearchQuery('')
+    setIsOpen(false)
+    setHighlightedIndex(-1)
+    inputRef.current?.blur()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter') {
+        setIsOpen(true)
+        setHighlightedIndex(0)
+      }
+      return
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setHighlightedIndex((prev) =>
+          prev < filteredGames.length - 1 ? prev + 1 : 0
+        )
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setHighlightedIndex((prev) =>
+          prev > 0 ? prev - 1 : filteredGames.length - 1
+        )
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (highlightedIndex >= 0 && filteredGames[highlightedIndex]) {
+          handleSelectGame(filteredGames[highlightedIndex])
+        }
+        break
+      case 'Escape':
+        setIsOpen(false)
+        setHighlightedIndex(-1)
+        inputRef.current?.blur()
+        break
+    }
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -35,6 +125,8 @@ export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
         setMessage({ type: 'success', text: result.message || 'Score submitted successfully!' })
         setScore('')
         setSelectedGame('')
+        setSelectedGameName('')
+        setSearchQuery('')
       } else {
         setMessage({ type: 'error', text: result.message || 'Failed to submit score' })
       }
@@ -49,21 +141,45 @@ export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
     <div className="bg-white rounded-xl p-6 shadow-sm">
       <h2 className="text-xl font-semibold mb-4">Add New Score</h2>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
+        <div className="relative" ref={dropdownRef}>
           <label className="block text-sm font-medium text-gray-700 mb-2">Game</label>
-          <select
-            value={selectedGame}
-            onChange={(e) => setSelectedGame(e.target.value)}
+          <input
+            ref={inputRef}
+            type="text"
+            value={displayValue}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            onKeyDown={handleKeyDown}
+            placeholder="Type to search games..."
             className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:outline-none focus:border-primary"
             required
-          >
-            <option value="">Select a game...</option>
-            {games.map((game) => (
-              <option key={game.id} value={game.id}>
-                {game.name}
-              </option>
-            ))}
-          </select>
+            autoComplete="off"
+          />
+          {isOpen && (
+            <div className="absolute z-50 w-full mt-1 bg-white border-2 border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
+              {filteredGames.length > 0 ? (
+                filteredGames.map((game, index) => (
+                  <button
+                    key={game.id}
+                    type="button"
+                    onClick={() => handleSelectGame(game)}
+                    className={`w-full px-4 py-2.5 text-left flex justify-between items-center transition-colors ${
+                      index === highlightedIndex
+                        ? 'bg-primary/10 text-primary'
+                        : 'hover:bg-gray-50'
+                    }`}
+                  >
+                    <span className="font-medium">{game.name}</span>
+                    <span className="text-sm text-gray-500">{game.category}</span>
+                  </button>
+                ))
+              ) : (
+                <div className="px-4 py-3 text-gray-500 text-sm">
+                  No games found. Try a different search.
+                </div>
+              )}
+            </div>
+          )}
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">Score</label>
@@ -88,7 +204,7 @@ export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
         )}
         <button
           type="submit"
-          disabled={loading}
+          disabled={loading || !selectedGame}
           className="w-full bg-primary text-white py-3 px-4 rounded-lg font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50"
         >
           {loading ? 'Submitting...' : 'Submit Score'}

--- a/components/ScoreEntryForm.tsx
+++ b/components/ScoreEntryForm.tsx
@@ -154,6 +154,7 @@ export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
             className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:outline-none focus:border-primary"
             required
             autoComplete="off"
+            data-cy="game-search-input"
           />
           {isOpen && (
             <div className="absolute z-50 w-full mt-1 bg-white border-2 border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto">
@@ -163,6 +164,9 @@ export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
                     key={game.id}
                     type="button"
                     onClick={() => handleSelectGame(game)}
+                    data-cy="game-option"
+                    data-cy-game-id={game.id}
+                    data-cy-game-name={game.name}
                     className={`w-full px-4 py-2.5 text-left flex justify-between items-center transition-colors ${
                       index === highlightedIndex
                         ? 'bg-primary/10 text-primary'

--- a/cypress/e2e/scores/delete-score.cy.ts
+++ b/cypress/e2e/scores/delete-score.cy.ts
@@ -26,29 +26,16 @@ describe('Score Deletion', () => {
     cy.visit('/score-entry')
     
     // Submit first score
-    cy.get('select').first().then(($select) => {
-      const firstOption = $select.find('option').eq(1).val() as string
-      const firstGameName = $select.find('option').eq(1).text()
-      
-      cy.get('select').first().select(firstOption)
-      cy.get('input[type="number"]').type('1000')
-      cy.get('button[type="submit"]').click()
-      
-      // Wait for success message
-      cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
-      
-      // Submit second score
-      cy.get('select').first().then(($select2) => {
-        const options = $select2.find('option')
-        if (options.length > 2) {
-          const secondOption = options.eq(2).val() as string
-          cy.get('select').first().select(secondOption)
-          cy.get('input[type="number"]').clear().type('2000')
-          cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
-        }
-      })
-    })
+    cy.selectGame(1)
+    cy.get('input[type="number"]').type('1000')
+    cy.get('button[type="submit"]').click()
+    cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+    
+    // Submit second score
+    cy.selectGame(2)
+    cy.get('input[type="number"]').clear().type('2000')
+    cy.get('button[type="submit"]').click()
+    cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
   })
 
   beforeEach(() => {
@@ -64,7 +51,7 @@ describe('Score Deletion', () => {
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
           // If no scores, submit one first
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -81,7 +68,7 @@ describe('Score Deletion', () => {
     it('should show delete button with trash icon', () => {
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -99,7 +86,7 @@ describe('Score Deletion', () => {
     it('should show confirmation dialog when delete button is clicked', () => {
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -122,7 +109,7 @@ describe('Score Deletion', () => {
     it('should cancel deletion when user clicks cancel in confirmation dialog', () => {
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -153,7 +140,7 @@ describe('Score Deletion', () => {
       // Ensure we have at least one score
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -190,7 +177,7 @@ describe('Score Deletion', () => {
 
     it('should remove score from the list after deletion', () => {
       // Submit a score first
-      cy.get('select').first().select(1)
+      cy.selectGame(1)
       cy.get('input[type="number"]').type('2500')
       cy.get('button[type="submit"]').click()
       cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -225,13 +212,13 @@ describe('Score Deletion', () => {
         
         if (scoreCount < 2) {
           // Submit additional scores
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('3000')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
           cy.reload()
 
-          cy.get('select').first().select(2)
+          cy.selectGame(2)
           cy.get('input[type="number"]').clear().type('4000')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -267,7 +254,7 @@ describe('Score Deletion', () => {
       // Ensure we have a score to delete
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -303,7 +290,7 @@ describe('Score Deletion', () => {
       })
 
       // Submit a new score
-      cy.get('select').first().select(1)
+      cy.selectGame(1)
       cy.get('input[type="number"]').type('5000')
       cy.get('button[type="submit"]').click()
       cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
@@ -333,7 +320,7 @@ describe('Score Deletion', () => {
       // Ensure we have a score
       cy.get('body').then(($body) => {
         if ($body.text().includes('No scores yet')) {
-          cy.get('select').first().select(1)
+          cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
           cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -25,6 +25,13 @@ declare global {
        * @example cy.logout()
        */
       logout(): Chainable<void>
+      
+      /**
+       * Select a game from the type-ahead dropdown (1-based index to match old select behavior)
+       * @example cy.selectGame(1) - select first game
+       * @example cy.selectGame(2) - select second game
+       */
+      selectGame(index: number): Chainable<void>
     }
   }
 }
@@ -52,6 +59,12 @@ Cypress.Commands.add('logout', () => {
   cy.get('button').contains(/^[A-Z]{1,2}$/).click()
   // Click sign out
   cy.contains('Sign Out').click()
+})
+
+// Select game from type-ahead (1-based index: 1 = first game, 2 = second game, etc.)
+Cypress.Commands.add('selectGame', (index: number) => {
+  cy.get('[data-cy="game-search-input"]').click()
+  cy.get('[data-cy="game-option"]').should('be.visible').eq(index - 1).click()
 })
 
 export {}

--- a/designs/static/dashboard.html
+++ b/designs/static/dashboard.html
@@ -68,6 +68,99 @@
         userMenu.classList.remove('open');
       }
     });
+
+    // Dashboard game type-ahead
+    const dashboardGames = [
+      { id: '1', name: 'Speed Match', category: 'Attention' },
+      { id: '2', name: 'Memory Matrix', category: 'Memory' },
+      { id: '3', name: 'Train of Thought', category: 'Attention' },
+      { id: '4', name: 'Word Bubbles', category: 'Flexibility' },
+      { id: '5', name: 'Ebb and Flow', category: 'Attention' }
+    ];
+
+    (function initDashboardGameTypeahead() {
+      const input = document.getElementById('dashboardGameSearch');
+      const dropdown = document.getElementById('dashboardGameDropdown');
+      const hiddenInput = document.getElementById('dashboardSelectedGameId');
+      let highlightedIndex = -1;
+
+      function filterGames(query) {
+        const q = query.toLowerCase();
+        return dashboardGames.filter(g => 
+          g.name.toLowerCase().includes(q) || g.category.toLowerCase().includes(q)
+        );
+      }
+
+      function renderDropdown(games) {
+        if (games.length === 0) {
+          dropdown.innerHTML = '<div class="game-typeahead-empty">No games found.</div>';
+        } else {
+          dropdown.innerHTML = games.map((g, i) => 
+            `<button type="button" class="game-typeahead-item" data-id="${g.id}" data-name="${g.name}" data-index="${i}">
+              <span class="game-typeahead-name">${g.name}</span>
+              <span class="game-typeahead-category">${g.category}</span>
+            </button>`
+          ).join('');
+        }
+        dropdown.style.display = 'block';
+        highlightedIndex = -1;
+      }
+
+      function selectGame(game) {
+        input.value = game.name;
+        hiddenInput.value = game.id;
+        dropdown.style.display = 'none';
+        input.blur();
+      }
+
+      input.addEventListener('input', function() {
+        hiddenInput.value = '';
+        renderDropdown(filterGames(this.value));
+      });
+
+      input.addEventListener('focus', function() {
+        const games = filterGames(this.value);
+        renderDropdown(games.length ? games : dashboardGames);
+      });
+
+      input.addEventListener('keydown', function(e) {
+        const items = dropdown.querySelectorAll('.game-typeahead-item');
+        if (items.length === 0) return;
+
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          highlightedIndex = (highlightedIndex + 1) % items.length;
+          items.forEach((el, i) => el.classList.toggle('highlighted', i === highlightedIndex));
+          items[highlightedIndex]?.scrollIntoView({ block: 'nearest' });
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          highlightedIndex = highlightedIndex <= 0 ? items.length - 1 : highlightedIndex - 1;
+          items.forEach((el, i) => el.classList.toggle('highlighted', i === highlightedIndex));
+          items[highlightedIndex]?.scrollIntoView({ block: 'nearest' });
+        } else if (e.key === 'Enter' && highlightedIndex >= 0 && items[highlightedIndex]) {
+          e.preventDefault();
+          const game = dashboardGames.find(g => g.id === items[highlightedIndex].dataset.id);
+          if (game) selectGame(game);
+        } else if (e.key === 'Escape') {
+          dropdown.style.display = 'none';
+          highlightedIndex = -1;
+        }
+      });
+
+      dropdown.addEventListener('click', function(e) {
+        const item = e.target.closest('.game-typeahead-item');
+        if (item) {
+          const game = dashboardGames.find(g => g.id === item.dataset.id);
+          if (game) selectGame(game);
+        }
+      });
+
+      document.addEventListener('click', function(e) {
+        if (!e.target.closest('.game-typeahead')) {
+          dropdown.style.display = 'none';
+        }
+      });
+    })();
   </script>
 
   <!-- Main Content -->
@@ -106,14 +199,11 @@
         <form>
           <div class="form-group">
             <label class="form-label">Game</label>
-            <select class="form-select">
-              <option>Select a game...</option>
-              <option>Speed Match</option>
-              <option>Memory Matrix</option>
-              <option>Train of Thought</option>
-              <option>Word Bubbles</option>
-              <option>Ebb and Flow</option>
-            </select>
+            <div class="game-typeahead" style="position: relative;">
+              <input type="text" id="dashboardGameSearch" class="form-input" placeholder="Type to search games..." autocomplete="off">
+              <input type="hidden" id="dashboardSelectedGameId" name="gameId">
+              <div id="dashboardGameDropdown" class="game-typeahead-dropdown" style="display: none;"></div>
+            </div>
           </div>
           <div class="form-group">
             <label class="form-label">Score</label>

--- a/designs/static/score-entry.html
+++ b/designs/static/score-entry.html
@@ -67,6 +67,109 @@
         userMenu.classList.remove('open');
       }
     });
+
+    // Game type-ahead data (matches optgroup structure from original design)
+    const gamesData = [
+      { id: '1', name: 'Speed Match', category: 'Attention' },
+      { id: '2', name: 'Train of Thought', category: 'Attention' },
+      { id: '3', name: 'Ebb and Flow', category: 'Attention' },
+      { id: '4', name: 'Memory Matrix', category: 'Memory' },
+      { id: '5', name: 'Memory Lane', category: 'Memory' },
+      { id: '6', name: 'Memory Match', category: 'Memory' },
+      { id: '7', name: 'Word Bubbles', category: 'Flexibility' },
+      { id: '8', name: 'Disillusion', category: 'Flexibility' },
+      { id: '9', name: 'Color Match', category: 'Flexibility' },
+      { id: '10', name: 'Speed Match Pro', category: 'Speed' },
+      { id: '11', name: 'Rush Hour', category: 'Speed' },
+      { id: '12', name: 'Raindrops', category: 'Problem Solving' },
+      { id: '13', name: 'Pet Detective', category: 'Problem Solving' },
+      { id: '14', name: 'Rotation Matrix', category: 'Problem Solving' }
+    ];
+
+    (function initGameTypeahead() {
+      const input = document.getElementById('gameSearch');
+      const dropdown = document.getElementById('gameDropdown');
+      const hiddenInput = document.getElementById('selectedGameId');
+      let highlightedIndex = -1;
+
+      function filterGames(query) {
+        const q = query.toLowerCase();
+        return gamesData.filter(g => 
+          g.name.toLowerCase().includes(q) || g.category.toLowerCase().includes(q)
+        );
+      }
+
+      function renderDropdown(games) {
+        if (games.length === 0) {
+          dropdown.innerHTML = '<div class="game-typeahead-empty">No games found. Try a different search.</div>';
+        } else {
+          dropdown.innerHTML = games.map((g, i) => 
+            `<button type="button" class="game-typeahead-item" data-id="${g.id}" data-name="${g.name}" data-index="${i}">
+              <span class="game-typeahead-name">${g.name}</span>
+              <span class="game-typeahead-category">${g.category}</span>
+            </button>`
+          ).join('');
+        }
+        dropdown.style.display = 'block';
+        highlightedIndex = -1;
+      }
+
+      function selectGame(game) {
+        input.value = game.name;
+        hiddenInput.value = game.id;
+        dropdown.style.display = 'none';
+        input.blur();
+      }
+
+      input.addEventListener('input', function() {
+        hiddenInput.value = '';
+        const games = filterGames(this.value);
+        renderDropdown(games);
+      });
+
+      input.addEventListener('focus', function() {
+        const games = filterGames(this.value);
+        renderDropdown(games.length ? games : gamesData);
+      });
+
+      input.addEventListener('keydown', function(e) {
+        const items = dropdown.querySelectorAll('.game-typeahead-item');
+        if (items.length === 0) return;
+
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          highlightedIndex = (highlightedIndex + 1) % items.length;
+          items.forEach((el, i) => el.classList.toggle('highlighted', i === highlightedIndex));
+          items[highlightedIndex]?.scrollIntoView({ block: 'nearest' });
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          highlightedIndex = highlightedIndex <= 0 ? items.length - 1 : highlightedIndex - 1;
+          items.forEach((el, i) => el.classList.toggle('highlighted', i === highlightedIndex));
+          items[highlightedIndex]?.scrollIntoView({ block: 'nearest' });
+        } else if (e.key === 'Enter' && highlightedIndex >= 0 && items[highlightedIndex]) {
+          e.preventDefault();
+          const game = gamesData.find(g => g.id === items[highlightedIndex].dataset.id);
+          if (game) selectGame(game);
+        } else if (e.key === 'Escape') {
+          dropdown.style.display = 'none';
+          highlightedIndex = -1;
+        }
+      });
+
+      dropdown.addEventListener('click', function(e) {
+        const item = e.target.closest('.game-typeahead-item');
+        if (item) {
+          const game = gamesData.find(g => g.id === item.dataset.id);
+          if (game) selectGame(game);
+        }
+      });
+
+      document.addEventListener('click', function(e) {
+        if (!e.target.closest('.game-typeahead')) {
+          dropdown.style.display = 'none';
+        }
+      });
+    })();
   </script>
 
   <!-- Main Content -->
@@ -79,34 +182,14 @@
       <form style="margin-top: 1.5rem;">
         <div class="form-group">
           <label class="form-label">Select Game</label>
-          <select class="form-select" style="font-size: 1rem;">
-            <option>Choose a game...</option>
-            <optgroup label="Attention">
-              <option>Speed Match</option>
-              <option>Train of Thought</option>
-              <option>Ebb and Flow</option>
-            </optgroup>
-            <optgroup label="Memory">
-              <option>Memory Matrix</option>
-              <option>Memory Lane</option>
-              <option>Memory Match</option>
-            </optgroup>
-            <optgroup label="Flexibility">
-              <option>Word Bubbles</option>
-              <option>Disillusion</option>
-              <option>Color Match</option>
-            </optgroup>
-            <optgroup label="Speed">
-              <option>Speed Match</option>
-              <option>Speed Match Pro</option>
-              <option>Rush Hour</option>
-            </optgroup>
-            <optgroup label="Problem Solving">
-              <option>Raindrops</option>
-              <option>Pet Detective</option>
-              <option>Rotation Matrix</option>
-            </optgroup>
-          </select>
+          <div class="game-typeahead" style="position: relative;">
+            <input type="text" id="gameSearch" class="form-input" placeholder="Type to search games..." autocomplete="off" style="font-size: 1rem; padding: 1rem;">
+            <input type="hidden" id="selectedGameId" name="gameId">
+            <div id="gameDropdown" class="game-typeahead-dropdown" style="display: none;"></div>
+          </div>
+          <div style="margin-top: 0.5rem; font-size: 0.875rem; color: var(--text-secondary);">
+            Start typing to quickly find your game
+          </div>
         </div>
 
         <div class="form-group">

--- a/designs/static/styles.css
+++ b/designs/static/styles.css
@@ -303,6 +303,63 @@ body {
   border-color: var(--primary);
 }
 
+/* Game Type-ahead */
+.game-typeahead-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 0.25rem;
+  background: var(--bg-white);
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 20px var(--shadow-lg);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.game-typeahead-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.game-typeahead-item:hover,
+.game-typeahead-item.highlighted {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--primary);
+}
+
+.game-typeahead-name {
+  font-weight: 500;
+}
+
+.game-typeahead-category {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.game-typeahead-item:hover .game-typeahead-category,
+.game-typeahead-item.highlighted .game-typeahead-category {
+  color: var(--primary);
+  opacity: 0.8;
+}
+
+.game-typeahead-empty {
+  padding: 1rem;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
 /* Stats */
 .stats-grid {
   display: grid;


### PR DESCRIPTION
Implement type-ahead functionality for game selection dropdowns to improve user experience.

Users complained about the game list being too long and difficult to navigate, so this change introduces a type-ahead feature allowing users to quickly search for games by name or category.

---
[Slack Thread](https://elabio.slack.com/archives/D0AHJGF2XAS/p1772328680637159?thread_ts=1772328680.637159&cid=D0AHJGF2XAS)

<p><a href="https://cursor.com/agents/bc-44938f70-cc2c-50c0-b8c7-3eafe27eb7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44938f70-cc2c-50c0-b8c7-3eafe27eb7db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

