### PR TITLE
Pr 14 test failure

### DIFF
--- a/components/ScoreEntryForm.tsx
+++ b/components/ScoreEntryForm.tsx
@@ -247,6 +247,7 @@ export default function ScoreEntryForm({ games, userId }: ScoreEntryFormProps) {
         </div>
         {message && (
           <div
+            data-cy={message.type === 'success' ? 'score-success-message' : 'score-error-message'}
             className={`p-3 rounded-lg ${
               message.type === 'success' ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-800'
             }`}

--- a/cypress/e2e/scores/delete-score.cy.ts
+++ b/cypress/e2e/scores/delete-score.cy.ts
@@ -29,13 +29,13 @@ describe('Score Deletion', () => {
     cy.selectGame(1)
     cy.get('input[type="number"]').type('1000')
     cy.get('button[type="submit"]').click()
-    cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+    cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
     
     // Submit second score
     cy.selectGame(2)
     cy.get('input[type="number"]').clear().type('2000')
     cy.get('button[type="submit"]').click()
-    cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+    cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
   })
 
   beforeEach(() => {
@@ -54,7 +54,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -71,7 +71,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -89,7 +89,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -112,7 +112,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -143,7 +143,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -180,7 +180,7 @@ describe('Score Deletion', () => {
       cy.selectGame(1)
       cy.get('input[type="number"]').type('2500')
       cy.get('button[type="submit"]').click()
-      cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+      cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
       cy.reload()
 
       // Get the game name from the score card (the .font-semibold inside the score card with delete button)
@@ -215,13 +215,13 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('3000')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
 
           cy.selectGame(2)
           cy.get('input[type="number"]').clear().type('4000')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -257,7 +257,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })
@@ -293,7 +293,7 @@ describe('Score Deletion', () => {
       cy.selectGame(1)
       cy.get('input[type="number"]').type('5000')
       cy.get('button[type="submit"]').click()
-      cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+      cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
     })
   })
 
@@ -323,7 +323,7 @@ describe('Score Deletion', () => {
           cy.selectGame(1)
           cy.get('input[type="number"]').type('1500')
           cy.get('button[type="submit"]').click()
-          cy.contains('Score submitted successfully', { timeout: 5000 }).should('be.visible')
+          cy.get('[data-cy="score-success-message"]', { timeout: 5000 }).should('be.visible')
           cy.reload()
         }
       })


### PR DESCRIPTION
Fixes CI failure in PR #14 by updating Cypress tests to account for new congratulatory messages.

PR #14 introduced new congratulatory messages for game leaders, which replaced the standard "Score submitted successfully" message. The Cypress tests were asserting on the exact text "Score submitted successfully", leading to failures. This PR updates the tests to target a `data-cy` attribute on the success message, making them robust to different success message texts.

---
[Slack Thread](https://elabio.slack.com/archives/D0AHJGF2XAS/p1772378658841839?thread_ts=1772378658.841839&cid=D0AHJGF2XAS)

<p><a href="https://cursor.com/agents/bc-e8660ab6-ab82-5f21-bf42-fa1dacdb394e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8660ab6-ab82-5f21-bf42-fa1dacdb394e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

