### PR TITLE
Leaderboard leader name

### DIFF
--- a/app/score-entry/page.tsx
+++ b/app/score-entry/page.tsx
@@ -84,7 +84,11 @@ export default async function ScoreEntryPage() {
                       )}
                       <div className="text-right">
                         <div className="text-2xl font-bold text-primary">{score.score.toLocaleString()}</div>
-                        <div className="text-xs text-gray-500">Personal Best</div>
+                        <div className="text-xs text-gray-500">
+                          {leaderByGame[score.gameId]?.username === user.username
+                            ? 'You'
+                            : leaderByGame[score.gameId]?.username ?? 'Personal Best'}
+                        </div>
                       </div>
                       <div className="flex-shrink-0">
                         <DeleteScoreButton scoreId={score.id} userId={user.id} gameName={score.game.name} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Display leader's name instead of 'Personal Best' in recent scores section to provide more personalized information.

The "Personal Best" label is replaced with the leader's username (or "You" if the current user is the leader) in the recent scores section. The necessary leader data was already available from the `leaderByGame` query, so only the display logic was updated.

---
[Slack Thread](https://elabio.slack.com/archives/C0AHTN1LKU7/p1772551405232599?thread_ts=1772551405.232599&cid=C0AHTN1LKU7)

<p><a href="https://cursor.com/agents/bc-8f69173c-bb1e-5cd2-97dc-7e7af91a9a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f69173c-bb1e-5cd2-97dc-7e7af91a9a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->