### PR TITLE
User name display issue

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -40,6 +40,24 @@ export default function LeaderboardPage() {
   const [games, setGames] = useState<Game[]>([])
   const [loading, setLoading] = useState(true)
   const [championsLoading, setChampionsLoading] = useState(true)
+  const [currentUser, setCurrentUser] = useState<{ username: string; role?: 'ADMIN' | 'MEMBER' } | null>(null)
+
+  useEffect(() => {
+    const fetchCurrentUser = async () => {
+      try {
+        const response = await fetch('/api/auth/current')
+        if (response.ok) {
+          const user = await response.json()
+          if (user) {
+            setCurrentUser({ username: user.username, role: user.role })
+          }
+        }
+      } catch (error) {
+        console.error('Error fetching current user:', error)
+      }
+    }
+    fetchCurrentUser()
+  }, [])
 
   useEffect(() => {
     // Load games from JSON
@@ -91,7 +109,7 @@ export default function LeaderboardPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header username="John Doe" />
+      <Header username={currentUser?.username ?? 'User'} role={currentUser?.role ?? 'MEMBER'} />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-white rounded-xl shadow-sm p-6">
           <div className="flex justify-between items-center mb-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update leaderboard page to display the actual username instead of "John Doe".

The leaderboard page was hardcoding "John Doe" as the username. This PR fetches the current user's details from `/api/auth/current` and passes the actual username and role to the header, consistent with other pages like friends/compare.

---
[Slack Thread](https://elabio.slack.com/archives/D0AHJGF2XAS/p1772634402157599?thread_ts=1772634402.157599&cid=D0AHJGF2XAS)

<p><a href="https://cursor.com/agents/bc-f1d81c18-b1cd-5feb-a032-f6ffc5799f70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1d81c18-b1cd-5feb-a032-f6ffc5799f70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->