### PR TITLE
CI test failure

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -20,8 +20,10 @@ const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter })
 
 if (!config.env.isProduction) globalForPrisma.prisma = prisma
 
+type GameRecord = { name: string; description: string; category: GameCategory; icon: string | null }
+
 // Read games from JSON file
-function loadGamesFromJSON() {
+function loadGamesFromJSON(): GameRecord[] {
   try {
     const jsonPath = join(process.cwd(), 'data', 'games.json')
     const fileContent = readFileSync(jsonPath, 'utf-8')
@@ -32,7 +34,8 @@ function loadGamesFromJSON() {
     }
 
     // Map JSON data to Prisma format, converting category string to enum
-    return data.games.map((game: { name: string; description: string; category: string; icon?: string }) => {
+    type GameInput = { name: string; description: string; category: string; icon?: string }
+    return data.games.map((game: GameInput): GameRecord => {
       // Validate and convert category string to enum
       const categoryMap: Record<string, GameCategory> = {
         ATTENTION: GameCategory.ATTENTION,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add explicit types to `prisma/seed.ts` to fix a TypeScript error causing CI failures.

The GitHub Actions pipeline failed due to a TypeScript error: `Type error: Parameter 'g' implicitly has an 'any' type.` in `prisma/seed.ts`. This PR introduces a `GameRecord` type and explicitly types the return of `loadGamesFromJSON()` and the map callback parameter `g` to resolve this.

[Slack Thread](https://elabio.slack.com/archives/D0AHJGF2XAS/p1773086562949079?thread_ts=1773086562.949079&cid=D0AHJGF2XAS)

<div><a href="https://cursor.com/agents/bc-7f34eed4-4834-5fdd-acca-86f32ab042f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f34eed4-4834-5fdd-acca-86f32ab042f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->